### PR TITLE
Fix variable typo in BalanceSheet

### DIFF
--- a/balancesheet/balance_sheet.py
+++ b/balancesheet/balance_sheet.py
@@ -153,8 +153,8 @@ class BalanceSheet(csv_processor):
         Returns:
             None
         """
-        pivotted_df = self.preprocess_and_pivot()
-        self.calculate_balances(pivotted_df)
+        pivoted_df = self.preprocess_and_pivot()
+        self.calculate_balances(pivoted_df)
         self.show_summary()
         self.carryover_data()
         self.save_summary(output_file_path)


### PR DESCRIPTION
## Summary
- fix variable name `pivoted_df` in BalanceSheet

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'csv_processor')*

------
https://chatgpt.com/codex/tasks/task_e_684a20c3c0ec83319e668a6545de2472